### PR TITLE
fix blueprint cap on walltime for bsub hour queue

### DIFF
--- a/rp_bin/blueprint
+++ b/rp_bin/blueprint
@@ -439,7 +439,7 @@ if ($job){
 
 
 	my $wallmin = $walltime * 60;
-	$wallmin = 240 if ($walltime > 240);
+	$wallmin = 240 if ($wallmin > 240);
 	my $wallstr = "-W $wallmin";
 
 


### PR DESCRIPTION
Change in `blueprint` for `bsub` queue, so that the hour queue's hard cap on runtime (240 minutes) is correctly checked using  `$wallmin` (walltime in minutes) rather than `$walltime` (in hours).

It looks like the same fix may apply to `msub` (the MSSM cluster), but not going to commit that change untested.