### PR TITLE
oct2015 patches

### DIFF
--- a/rp_bin/haps2dos4
+++ b/rp_bin/haps2dos4
@@ -258,7 +258,9 @@ unless (-e $twodos_tmp_success) {
 
 # check success
 # if successful, remove $haps_file_gz now to save space
-unless (-e $twodos_tmp_success) {
+if (-e $twodos_tmp_success) {
+    &mysystem("rm $haps_file_gz")
+} else {
     die "Failed to create $twodos_tmp from $haps_file_gz";
 }
 
@@ -328,6 +330,6 @@ close BC;
 
 
 &mysystem ("touch $finiout");
-&mysystem ("rm $haps_file_gz");
+&mysystem ("rm $twodos_tmp");
 
 print "done\n";

--- a/rp_bin/rp_config
+++ b/rp_bin/rp_config
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use File::Basename;
 use Cwd;
@@ -1081,15 +1081,15 @@ if ($clusters{co_ipsych} == 1) {
 
 
 print "-------------------------------------------------------------------\n";
-print "adding these commands to your ~/.bashrc can be very helpful\n(just copy/paste the follwong lines into ~/.bashrc)\n(you have to logout and login again for this to be in effect)\n\n";
+print "adding these commands to your ~/.bashrc can be very helpful\n(just copy/paste the following lines into ~/.bashrc)\n(you have to logout and login again for these to take effect)\n\n";
 print "## for colored output of ls:\n";
 print 'alias ls=\'ls --color=auto\''."\n\n";
 print "## for easy copy over to your local machine:\n";
 print 'alias c=\'sed "s#.*#scp '.$ENV{LOGNAME}.'@'.$hostname.':$(pwd)/& .#"\''."\n\n";
 
 
-print "## for list of commands:\n";
-if ($clusters{lisa} == 1 || $clusters{computerome} == 1 || $clusters{co_ipsych} == 1) {
+print "## for list of cluster jobs:\n";
+if ($clusters{lisa} == 1 || $clusters{computerome} == 1 || $clusters{co_ipsych} == 1 || $clusters{broad} == 1) {
     print 'alias q=\'qstat -u '.$ENV{LOGNAME}."\'\n\n";
 }
 else {
@@ -1103,10 +1103,7 @@ if ($clusters{computerome} == 1) {
 }
 
 print "## different prompt:\n";
-print 'PS1="$USER@computerome.cbs.dtu.dk:"\'\w\'" "'."\n\n";  
-
-print "## different prompt:\n";
-print 'PS1="$USER@ipsych.computerome.cbs.dtu.dk:"\'\w\'" "'."\n\n";  
+print 'PS1="'.$ENV{USER}.'@'.$hostname.':"\'\w\'" "'."\n\n";
   
 
 print "-------------------------------------------------------------------\n";    


### PR DESCRIPTION
Joint patch to re-apply previous updates reverted by the oct2015 update, plus other pending fixes.

Previous updates re-applied here are:
- #9/#12: improve text of command suggestions at end of `rp_config`
- #7/#14: cleanup of temporary files while converting imputation dosage format

Additional changes included here:
- #16: prevent errors from rpac, rloc config variables during installations
- #17: fix wallclock time settings for `bsub` queue