### PR TITLE
allow qsub_b to still catch nearly-empty chunks failing shapeit

### DIFF
--- a/rp_bin/impute_dirsub_57
+++ b/rp_bin/impute_dirsub_57
@@ -93,10 +93,6 @@ my $spliha_n = 1500; ## split haplotypes with N individuals
 
 my $best_lahunt = 5;
 
-my $multithread1 = 4;
-my $multithread2 = 8;
-
-
 my $phas = -1;
 
 
@@ -249,6 +245,13 @@ my $freq_th = 0.005;
 my $bg_th = 0.8;
 
 my $sjamem_incr = 0;
+
+my $multithread1 = 4;
+my $multithread2 = 8;
+if ($qloc eq "qsub_b"){
+    $multithread1 = 1;
+}
+
 #exit;
 
 my $sec_freq = .2;  ## secure freq distance around 50%
@@ -2221,12 +2224,7 @@ if ($prephase_done == 0) {
 			push @preph_arr, $backbone;
 		    }
 		    if ($multi_sw == 1) {
-			if ($qloc eq "qsub_b"){
-			    push @preph_arr_mu1, $backbone;
-			}
-			else {
-			    push @preph_arr_mu1, $backbone." $multi_txt";
-			}
+		    	push @preph_arr_mu1, $backbone." $multi_txt";
 		    }
 		    print "multi: $multi_sw\n";
 		    if ($multi_sw == 2) {
@@ -2300,21 +2298,43 @@ if ($prephase_done == 0) {
 
     if (@preph_arr_mu2 > 0) {
 
-
+	# no multithread on broad makes another resub pointless, so fail here
 	if ($qloc eq "qsub_b") {
-	    print "Error: multithread currently not supported at Broad\n";
+
+	    $sjaname = "preph_mu1" ;
+	    my $err_message ;
+	    $err_message .= "##################################################################\n";
+	    $err_message .= "##### Error: \n";
+    	    $err_message .= "##### step $sjaname has been done repeatedly without any progress\n";
+    	    $err_message .= "##### imputation pipeline stopped: $command_line\n";
+    	    $err_message .= "##### $sjainfotxt\n";
+   	    $err_message .= "##### if reason does not appear obvious\n";
+    	    $err_message .= "##### have a look at the wiki page\n"; 
+    	    $err_message .= "##### https://sites.google.com/a/broadinstitute.org/ricopili/\n";
+    	    $err_message .= "##### or contact the developers\n";
+    	    $err_message .= "##################################################################\n";
+    	    print "$err_message\n";
+
+    	    die $! unless open ERR, "> error_file";
+    	    print ERR $err_message."\n";
+    	    close ERR;
+
+    	    &mysystem ('cat error_file | '.$mutt_script.' -s RP_pipeline_error '.$email) ;
 	    exit;
+
+	} else {
+
+	    $sjadir = $impute_dir;
+	    $sjaname = "preph_mu2";
+	    $sjatime = 4;
+	    $sjaweek = 1;
+	    $sjamulti = $multithread2;
+	    $sjamem = 4000;
+	    @sjaarray = @preph_arr_mu2;
+
+	    &send_jobarray;
+
 	}
-	$sjadir = $impute_dir;
-	$sjaname = "preph_mu2";
-	$sjatime = 4;
-	$sjaweek = 1;
-	$sjamulti = $multithread2;
-	$sjamem = 4000;
-	@sjaarray = @preph_arr_mu2;
-
-	&send_jobarray;
-
     }
     else {
 	&mysystem ("touch $rootdir/prephase_done");

--- a/rp_bin/my.preph2
+++ b/rp_bin/my.preph2
@@ -84,7 +84,7 @@ if ($chrx) {
 }
 
 my $multi_txt = "";
-if ($multi > 0 ) {
+if ($multi > 1 ) {
     $multi_txt = "--thread $multi";
 }
 


### PR DESCRIPTION
Allows nearly-empty genomic chunks failing shapeit to be caught on Broad (`qsub_b`) as intended (and is already working on other platforms). See #23.