### PR TITLE
fix blueprint cap on walltime for bsub hour queue

### DIFF
--- a/rp_bin/blueprint
+++ b/rp_bin/blueprint
@@ -439,7 +439,7 @@ if ($job){
 
 
 	my $wallmin = $walltime * 60;
-	$wallmin = 240 if ($walltime > 240);
+	$wallmin = 240 if ($wallmin > 240);
 	my $wallstr = "-W $wallmin";
 
 


### PR DESCRIPTION
Fix on queue settings for `bsub`. See #17, #22.

Note: No direct impact from this change since the `bsub` queue is no longer in use (Broad switched to `qsub_b`), but still worth having it fixed in case `bsub` gets put back into service for some other cluster location.