### PR TITLE
resub dosage jobs to long queue, not short

### DIFF
--- a/rp_bin/impute_dirsub_57
+++ b/rp_bin/impute_dirsub_57
@@ -2799,7 +2799,7 @@ if ($dos_done == 0) {
 	$sjadir = $impute_dir;
 	$sjaname = "dos";
 	$sjatime = 2;
-#	$sjatime = 4 if ($dos_fini > 0);
+	$sjatime = 4 if ($dos_fini > 0);
 	$sjamem = 2000;
 	$sjamaxpar = 100;
 	@sjaarray = @dos_arr;


### PR DESCRIPTION
Addresses issue where some dosage jobs for very large datasets aren't able to complete in short queues (walltime 2 hours), and thus should indeed switch to long queue when resubmitting failed tasks. 

This probably has a potential performance cost for smaller datasets on platforms where stochastic job failures occur at non-trivial rates and the long queue has substantially slower dispatch times or low caps on maximum simultaneous jobs. If this is a significant concern, it might be worth adding additional logic to pick the resubmit queue based on sample size.